### PR TITLE
Target Node.js 18, update dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,4 +19,4 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
-      - run: npm test
+      - run: script -e -c "npm test"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,12 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 16
+          - 18
+          - 20
+          - 21
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/cli.js
+++ b/cli.js
@@ -29,7 +29,5 @@ if (!input && process.stdin.isTTY) {
 if (input) {
 	init(input);
 } else {
-	(async () => {
-		init(await getStdin());
-	})();
+	init(await getStdin());
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"strip-ansi": "./cli.js"
 	},
 	"engines": {
-		"node": ">=12.17"
+		"node": ">=18"
 	},
 	"scripts": {
 		"test": "xo && ava"
@@ -51,12 +51,12 @@
 	],
 	"dependencies": {
 		"get-stdin": "^9.0.0",
-		"meow": "^10.1.1",
-		"strip-ansi": "^7.0.1"
+		"meow": "^13.1.0",
+		"strip-ansi": "^7.1.0"
 	},
 	"devDependencies": {
-		"ava": "^3.15.0",
-		"execa": "^5.1.1",
-		"xo": "^0.44.0"
+		"ava": "^6.1.0",
+		"execa": "^8.0.1",
+		"xo": "^0.56.0"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -13,7 +13,7 @@ test('stdin', async t => {
 	t.is(stdout, 'foofoo');
 });
 
-// NOTE: This test assumes AVA is run from a TTY terminal
+// NOTE: This test assumes AVA is run in a TTY environment
 test('no input', async t => {
 	/** @type {import('execa').ExecaError} */
 	const error = await t.throwsAsync(execa('./cli.js', {stdin: 'inherit'}));

--- a/test.js
+++ b/test.js
@@ -13,6 +13,7 @@ test('stdin', async t => {
 	t.is(stdout, 'foofoo');
 });
 
+// NOTE: This test assumes AVA is run from a TTY terminal
 test('no input', async t => {
 	/** @type {import('execa').ExecaError} */
 	const error = await t.throwsAsync(execa('./cli.js', {stdin: 'inherit'}));

--- a/test.js
+++ b/test.js
@@ -1,14 +1,24 @@
 import test from 'ava';
-import execa from 'execa';
+import {execa} from 'execa';
+
+const fixture = '\u001B[0m\u001B[4m\u001B[42m\u001B[31mfoo\u001B[39m\u001B[49m\u001B[24mfoo\u001B[0m';
 
 test('main', async t => {
-	const {stdout} = await execa('./cli.js', ['--version']);
-	t.true(stdout.length > 0);
+	const {stdout} = await execa('./cli.js', [fixture]);
+	t.is(stdout, 'foofoo');
 });
 
 test('stdin', async t => {
-	const {stdout} = await execa('./cli.js', {
-		input: '\u001B[0m\u001B[4m\u001B[42m\u001B[31mfoo\u001B[39m\u001B[49m\u001B[24mfoo\u001B[0m',
-	});
+	const {stdout} = await execa('./cli.js', {input: fixture});
 	t.is(stdout, 'foofoo');
+});
+
+test('no input', async t => {
+	/** @type {import('execa').ExecaError} */
+	const error = await t.throwsAsync(execa('./cli.js', {stdin: 'inherit'}));
+
+	t.like(error, {
+		stderr: 'Input required',
+		exitCode: 1,
+	});
 });


### PR DESCRIPTION
This PR:

- Targets Node.js 18
- Updates dependencies (specifically to get [`strip-ansi` v7.1.0](https://github.com/chalk/strip-ansi/releases/tag/v7.1.0))
- Improves tests, covering a previously untested case